### PR TITLE
Install application to default location

### DIFF
--- a/Casks/carta-beta.rb
+++ b/Casks/carta-beta.rb
@@ -1,15 +1,11 @@
 cask 'carta-beta' do
-  if Hardware::CPU.arm?
-    # Native Apple Silicon version
-    version '5.0.0-beta.1'
-    sha256 '237bc0a47258cd6b39609c503078cd069ec7a22b0a43763c445c9560de3d4782'
-    url 'https://github.com/CARTAvis/carta/releases/download/v5.0.0-beta.1/CARTA-v5.0.0-beta.1-arm64_OS15.4.dmg'
-  else
-    # Native Intel version
-    version '5.0.0-beta.1'
-    sha256 '3976c716b879df4524e694458a9314cd606a35ac28a5ab0ea78d475590222802'
-    url 'https://github.com/CARTAvis/carta/releases/download/v5.0.0-beta.1/CARTA-v5.0.0-beta.1-x64.dmg'
-  end
+  arch arm: "arm64_OS15.4", intel: "x64"
+
+  version "5.0.0-beta.1"
+  sha256 arm:   "237bc0a47258cd6b39609c503078cd069ec7a22b0a43763c445c9560de3d4782",
+         intel: "3976c716b879df4524e694458a9314cd606a35ac28a5ab0ea78d475590222802"
+  url "https://github.com/CARTAvis/carta/releases/download/v#{version}/CARTA-v#{version}-#{arch}.dmg",
+      verified: "github.com/CARTAvis/carta/releases/download"
 
   name 'CARTA'
   desc 'Electron version of CARTA provided as a Homebrew Cask'
@@ -36,5 +32,4 @@ cask 'carta-beta' do
     bin_path = "#{bin_dir}/carta-beta"
     system_command '/bin/rm', args: [bin_path]
   end
-
 end

--- a/Casks/carta-beta.rb
+++ b/Casks/carta-beta.rb
@@ -1,46 +1,45 @@
 cask 'carta-beta' do
-    if Hardware::CPU.arm?
-      # Native Apple Silicon version
-      version '5.0.0-beta.1'
-      sha256 '237bc0a47258cd6b39609c503078cd069ec7a22b0a43763c445c9560de3d4782'
-      url 'https://github.com/CARTAvis/carta/releases/download/v5.0.0-beta.1/CARTA-v5.0.0-beta.1-arm64_OS15.4.dmg'
-    else
-      # Native Intel version
-      version '5.0.0-beta.1'
-      sha256 '3976c716b879df4524e694458a9314cd606a35ac28a5ab0ea78d475590222802'
-      url 'https://github.com/CARTAvis/carta/releases/download/v5.0.0-beta.1/CARTA-v5.0.0-beta.1-x64.dmg'
-    end
-  
-    name 'CARTA'
-    desc 'Electron version of CARTA provided as a Homebrew Cask'
-    homepage 'https://cartavis.org'
-  
-    if Hardware::CPU.arm?
-      app 'CARTA-v5.0.0-beta.1.app' , target: '/opt/homebrew/Caskroom/CARTA-v5.0.0-beta.1.app'
-    else
-      app 'CARTA-v5.0.0-beta.1.app' , target: '/usr/local/Caskroom/CARTA-v5.0.0-beta.1.app'
-    end
-  
-    postflight do
-      # Setup a 'carta' executable to the 'carta.sh' script.
-      # The 'carta.sh' bypasses the Electron component so that the user's default web browser is used to display the carta-frontend.
-      bin_dir = Hardware::CPU.arm? ? '/opt/homebrew/bin' : '/usr/local/bin'
-      bin_path = "#{bin_dir}/carta-beta"
-      carta_dir = Hardware::CPU.arm? ? '/opt/homebrew/Caskroom' : '/usr/local/Caskroom'
-  
-      File.write(bin_path, <<~EOS)
-        #!/bin/bash
-        #{carta_dir}/CARTA-v5.0.0-beta.1.app/Contents/Resources/app/carta-backend/bin/carta.sh "$@"
-      EOS
-      system_command '/bin/chmod', args: ['755', bin_path]
-    end
-  
-    uninstall_postflight do
-      # Remove the custom 'carta' executable on uninstall
-      bin_dir = Hardware::CPU.arm? ? '/opt/homebrew/bin' : '/usr/local/bin'
-      bin_path = "#{bin_dir}/carta-beta"
-      system_command '/bin/rm', args: [bin_path]
-    end
-  
+  if Hardware::CPU.arm?
+    # Native Apple Silicon version
+    version '5.0.0-beta.1'
+    sha256 '237bc0a47258cd6b39609c503078cd069ec7a22b0a43763c445c9560de3d4782'
+    url 'https://github.com/CARTAvis/carta/releases/download/v5.0.0-beta.1/CARTA-v5.0.0-beta.1-arm64_OS15.4.dmg'
+  else
+    # Native Intel version
+    version '5.0.0-beta.1'
+    sha256 '3976c716b879df4524e694458a9314cd606a35ac28a5ab0ea78d475590222802'
+    url 'https://github.com/CARTAvis/carta/releases/download/v5.0.0-beta.1/CARTA-v5.0.0-beta.1-x64.dmg'
   end
-  
+
+  name 'CARTA'
+  desc 'Electron version of CARTA provided as a Homebrew Cask'
+  homepage 'https://cartavis.org'
+
+  if Hardware::CPU.arm?
+    app 'CARTA-v5.0.0-beta.1.app' , target: '/opt/homebrew/Caskroom/CARTA-v5.0.0-beta.1.app'
+  else
+    app 'CARTA-v5.0.0-beta.1.app' , target: '/usr/local/Caskroom/CARTA-v5.0.0-beta.1.app'
+  end
+
+  postflight do
+    # Setup a 'carta' executable to the 'carta.sh' script.
+    # The 'carta.sh' bypasses the Electron component so that the user's default web browser is used to display the carta-frontend.
+    bin_dir = Hardware::CPU.arm? ? '/opt/homebrew/bin' : '/usr/local/bin'
+    bin_path = "#{bin_dir}/carta-beta"
+    carta_dir = Hardware::CPU.arm? ? '/opt/homebrew/Caskroom' : '/usr/local/Caskroom'
+
+    File.write(bin_path, <<~EOS)
+      #!/bin/bash
+      #{carta_dir}/CARTA-v5.0.0-beta.1.app/Contents/Resources/app/carta-backend/bin/carta.sh "$@"
+    EOS
+    system_command '/bin/chmod', args: ['755', bin_path]
+  end
+
+  uninstall_postflight do
+    # Remove the custom 'carta' executable on uninstall
+    bin_dir = Hardware::CPU.arm? ? '/opt/homebrew/bin' : '/usr/local/bin'
+    bin_path = "#{bin_dir}/carta-beta"
+    system_command '/bin/rm', args: [bin_path]
+  end
+
+end

--- a/Casks/carta-beta.rb
+++ b/Casks/carta-beta.rb
@@ -15,22 +15,17 @@ cask 'carta-beta' do
   desc 'Electron version of CARTA provided as a Homebrew Cask'
   homepage 'https://cartavis.org'
 
-  if Hardware::CPU.arm?
-    app 'CARTA-v5.0.0-beta.1.app' , target: '/opt/homebrew/Caskroom/CARTA-v5.0.0-beta.1.app'
-  else
-    app 'CARTA-v5.0.0-beta.1.app' , target: '/usr/local/Caskroom/CARTA-v5.0.0-beta.1.app'
-  end
+  app "CARTA-v#{version}.app"
 
   postflight do
     # Setup a 'carta' executable to the 'carta.sh' script.
     # The 'carta.sh' bypasses the Electron component so that the user's default web browser is used to display the carta-frontend.
     bin_dir = Hardware::CPU.arm? ? '/opt/homebrew/bin' : '/usr/local/bin'
     bin_path = "#{bin_dir}/carta-beta"
-    carta_dir = Hardware::CPU.arm? ? '/opt/homebrew/Caskroom' : '/usr/local/Caskroom'
 
     File.write(bin_path, <<~EOS)
       #!/bin/bash
-      #{carta_dir}/CARTA-v5.0.0-beta.1.app/Contents/Resources/app/carta-backend/bin/carta.sh "$@"
+      #{appdir}/CARTA-v#{version}.app/Contents/Resources/app/carta-backend/bin/carta.sh "$@"
     EOS
     system_command '/bin/chmod', args: ['755', bin_path]
   end

--- a/Casks/carta.rb
+++ b/Casks/carta.rb
@@ -15,22 +15,17 @@ cask 'carta' do
   desc 'Electron version of CARTA provided as a Homebrew Cask'
   homepage 'https://cartavis.org'
 
-  if Hardware::CPU.arm?
-    app 'CARTA.app' , target: '/opt/homebrew/Caskroom/CARTA.app'
-  else
-    app 'CARTA.app' , target: '/usr/local/Caskroom/CARTA.app'
-  end
+  app "CARTA.app"
 
   postflight do
     # Setup a 'carta' executable to the 'carta.sh' script.
     # The 'carta.sh' bypasses the Electron component so that the user's default web browser is used to display the carta-frontend.
     bin_dir = Hardware::CPU.arm? ? '/opt/homebrew/bin' : '/usr/local/bin'
     bin_path = "#{bin_dir}/carta"
-    carta_dir = Hardware::CPU.arm? ? '/opt/homebrew/Caskroom' : '/usr/local/Caskroom'
 
     File.write(bin_path, <<~EOS)
       #!/bin/bash
-      #{carta_dir}/CARTA.app/Contents/Resources/app/carta-backend/bin/carta.sh "$@"
+      #{appdir}/CARTA.app/Contents/Resources/app/carta-backend/bin/carta.sh "$@"
     EOS
     system_command '/bin/chmod', args: ['755', bin_path]
   end

--- a/Casks/carta.rb
+++ b/Casks/carta.rb
@@ -1,15 +1,11 @@
 cask 'carta' do
-  if Hardware::CPU.arm?
-    # Native Apple Silicon version
-    version '4.1.0'
-    sha256 '4adc6a7429de51fcf55befb27166c4543353ef230a51cc4c37aab290fa51b572'
-    url 'https://github.com/CARTAvis/carta/releases/download/v4.1.0/CARTA-v4.1.0-arm64.dmg'
-  else
-    # Native Intel version
-    version '4.1.0'
-    sha256 '6ef4c59053687f64010a581302ae4cde5a31992251a6824083533e726e761147'
-    url 'https://github.com/CARTAvis/carta/releases/download/v4.1.0/CARTA-v4.1.0-x64.dmg'
-  end
+  arch arm: "arm64", intel: "x64"
+
+  version "4.1.0"
+  sha256 arm:   "4adc6a7429de51fcf55befb27166c4543353ef230a51cc4c37aab290fa51b572",
+         intel: "6ef4c59053687f64010a581302ae4cde5a31992251a6824083533e726e761147"
+  url "https://github.com/CARTAvis/carta/releases/download/v#{version}/CARTA-v#{version}-#{arch}.dmg",
+      verified: "github.com/CARTAvis/carta/releases/download"
 
   name 'CARTA'
   desc 'Electron version of CARTA provided as a Homebrew Cask'
@@ -36,5 +32,4 @@ cask 'carta' do
     bin_path = "#{bin_dir}/carta"
     system_command '/bin/rm', args: [bin_path]
   end
-
 end


### PR DESCRIPTION
Install the application to the default location.

The current versions of the casks install CARTA into the `Caskroom` directory in the Homebrew tree, which produces confusing results. If you install the `carta` cask with
```
brew install --cask CARTAvis/tap/carta
```
then when you list the casks with `brew list --cask`, CARTA appears twice:
```
CARTA.app
carta
```
The second item is the `carta` directory for the cask, as expected, but the application itself has ended up there too.

A couple of other minor fixes:
- Fix indentation in carta-beta cask
- Remove the architecture branches for the version/sha256/url stanzas